### PR TITLE
Rename method for better understanding

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,27 @@ this will check for null, empty string and white spaces string
 and throw it corresponding exception.
 
 ## Installation
+
 Via [NuGet](https://www.nuget.org/packages/StringExceptions/)
+
 ```shell
-Install-Package StringExceptions -Version 1.0.1
+Install-Package StringExceptions -Version 1.1.0
 ```
 
 ## Usage
+
 ```c#
 using StringExceptions;
 
-StringExceptionsChecker.Throw(myString);
+StringExceptionsChecker.ThrowIfFails(myString);
 // or
-StringExceptionsChecker.Throw(myString, nameof(myString));
+StringExceptionsChecker.ThrowIfFails(myString, nameof(myString));
 ```
 
 ## Exceptions
+
 Three exception classes are declared:
+
 - **StringEmptyException**: Throws when string is empty.
-- **StringNullException**: Throws when string is null. (Inherited from *ArgumentNullException*).
+- **StringNullException**: Throws when string is null. (Inherited from _ArgumentNullException_).
 - **StringWhiteSpaceException**: Throws when string is ony formed by whitespaces.

--- a/StringExceptions/StringExceptions.csproj
+++ b/StringExceptions/StringExceptions.csproj
@@ -6,8 +6,8 @@
         <Nullable>enable</Nullable>
         <Authors>Merino Fajardo</Authors>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <PackageReleaseNotes>Include generated documentation files.</PackageReleaseNotes>
-        <PackageVersion>1.0.1</PackageVersion>
+        <PackageReleaseNotes>Rename method to something for meaningful for the developer.</PackageReleaseNotes>
+        <PackageVersion>1.1.0</PackageVersion>
         <PackageProjectUrl>https://github.com/merinofg/StringExceptions</PackageProjectUrl>
         <PackageId>StringExceptions</PackageId>
         <Description>Simplifies the string checks for common cases as null,

--- a/StringExceptions/StringExceptionsChecker.cs
+++ b/StringExceptions/StringExceptionsChecker.cs
@@ -17,7 +17,7 @@
         /// <exception cref="StringNullException"><paramref name="s"/> is <c>null</c>.</exception>
         /// <exception cref="StringEmptyException"><paramref name="s"/> is an empty string.</exception>
         /// <exception cref="StringWhiteSpaceException"><paramref name="s"/> is only whitespaces.</exception>
-        public static void Throw(string? s, string? paramName = default)
+        public static void ThrowIfFails(string? s, string? paramName = default)
         {
             switch (s)
             {

--- a/Test/StringExceptionsCheckerTest.cs
+++ b/Test/StringExceptionsCheckerTest.cs
@@ -14,7 +14,7 @@ namespace Test
         [Test]
         public void WhenThrowIsCalledWithStringContainingText_ThenNothingIsThrown()
         {
-            Assert.DoesNotThrow(() => StringExceptionsChecker.Throw(_string_with_content));
+            Assert.DoesNotThrow(() => StringExceptionsChecker.ThrowIfFails(_string_with_content));
         }
 
         [Test]
@@ -23,7 +23,7 @@ namespace Test
             var argumentNullException = new ArgumentNullException();
 
             var exception = Assert.Throws<StringNullException>(
-            () => StringExceptionsChecker.Throw(_string_null));
+            () => StringExceptionsChecker.ThrowIfFails(_string_null));
 
             Assert.That(exception!.Message, Is.EqualTo(argumentNullException.Message));
         }
@@ -34,7 +34,7 @@ namespace Test
             var argumentNullException = new ArgumentNullException(nameof(_string_null));
 
             var exception = Assert.Throws<StringNullException>(
-                () => StringExceptionsChecker.Throw(_string_null, nameof(_string_null)));
+                () => StringExceptionsChecker.ThrowIfFails(_string_null, nameof(_string_null)));
 
             Assert.That(exception!.Message, Is.EqualTo(argumentNullException.Message));
         }
@@ -45,7 +45,7 @@ namespace Test
             const string expectedMessage = $"Value is an empty string.";
 
             var exception = Assert.Throws<StringEmptyException>(
-            () => StringExceptionsChecker.Throw(_string_empty));
+            () => StringExceptionsChecker.ThrowIfFails(_string_empty));
 
             Assert.That(exception!.Message, Is.EqualTo(expectedMessage));
         }
@@ -56,7 +56,7 @@ namespace Test
             const string expectedMessage = $"{nameof(_string_empty)}: Value is an empty string.";
 
             var exception = Assert.Throws<StringEmptyException>(
-                () => StringExceptionsChecker.Throw(_string_empty, nameof(_string_empty)));
+                () => StringExceptionsChecker.ThrowIfFails(_string_empty, nameof(_string_empty)));
 
             Assert.That(exception!.Message, Is.EqualTo(expectedMessage));
         }
@@ -67,7 +67,7 @@ namespace Test
             const string expectedMessage = "Value only contains whitespaces.";
 
             var exception = Assert.Throws<StringWhiteSpaceException>(
-            () => StringExceptionsChecker.Throw(_string_whitespace));
+            () => StringExceptionsChecker.ThrowIfFails(_string_whitespace));
 
             Assert.That(exception!.Message, Is.EqualTo(expectedMessage));
         }
@@ -78,7 +78,7 @@ namespace Test
             const string expectedMessage = $"{nameof(_string_whitespace)}: Value only contains whitespaces.";
 
             var exception = Assert.Throws<StringWhiteSpaceException>(
-                () => StringExceptionsChecker.Throw(_string_whitespace, nameof(_string_whitespace)));
+                () => StringExceptionsChecker.ThrowIfFails(_string_whitespace, nameof(_string_whitespace)));
 
             Assert.That(exception!.Message, Is.EqualTo(expectedMessage));
         }


### PR DESCRIPTION
This PR aims to rename the method from `Throw` to `ThrowIfFails`.

The reason is that, when coding, reading `StringExceptionsChecker.Throw(aString)` gives the programmer the feeling that the called method will throw an exception no mater what.

`ThrowIfFails` gives the programmer a better understanding of what is going to happen, and when.